### PR TITLE
Update /metrics to always report by 1 namespace only.

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,17 @@
+ARG UBUNTU_VER=bionic-20190912.1
+
+FROM ubuntu:${UBUNTU_VER}
+
+ENV GOPATH /root/go
+RUN apt-get update \
+  && apt-get install -y \
+    curl \
+    git \
+    golang \
+    go-dep \
+    libsystemd-dev
+
+WORKDIR ${GOPATH}/src/github.com/box/kube-iptables-tailer
+ADD . .
+
+CMD ["/bin/bash"]

--- a/event/locator.go
+++ b/event/locator.go
@@ -152,6 +152,23 @@ func getNamespaceOrHostName(pod *v1.Pod, ip string, resolver DnsResolver) string
 	return getHostName(resolver, ip)
 }
 
+/*
+ * 1. If a pod is not using host networking, return its namespace name.
+ * 2. If a pod is using host networking, return "hostNetwork".
+ * 3. If no pod is found, return "external".
+ */
+func getNamespaceOnly(pod *v1.Pod) string {
+	if pod != nil {
+		if !pod.Spec.HostNetwork {
+			return pod.Namespace
+		}
+		if pod.Spec.NodeName != "" {
+			return "hostNetwork"
+		}
+	}
+	return "external"
+}
+
 // Helper function to construct packet drop message
 func getPacketDropMessage(otherSideServiceName string, ip string, direction TrafficDirection) string {
 	var buffer bytes.Buffer

--- a/event/locator_test.go
+++ b/event/locator_test.go
@@ -62,6 +62,42 @@ func TestGetServiceNameFromIP(t *testing.T) {
 	}
 }
 
+// Test if getNamespaceOnly() works
+func TestGetNamespaceFromPod(t *testing.T) {
+	// test for pod not using hostNetworking
+	expected := "test-namespace"
+	pod := &v1.Pod{}
+	pod.Namespace = expected
+	pod.Spec.HostNetwork = false
+	result := getNamespaceOnly(pod)
+	if result != expected {
+		t.Fatalf("Expected: %v, but got result: %v", expected, result)
+	}
+
+	// test for pod using hostNetworking but without spec.NodeName
+	expected = "external"
+	pod.Spec.HostNetwork = true
+	result = getNamespaceOnly(pod)
+	if result != expected {
+		t.Fatalf("Expected: %v, but got result: %v", expected, result)
+	}
+
+	// test for pod using hostNetworking but with spec.NodeName
+	expected = "hostNetwork"
+	pod.Spec.NodeName = "test-host-name"
+	result = getNamespaceOnly(pod)
+	if result != expected {
+		t.Fatalf("Expected: %v, but got result: %v", expected, result)
+	}
+
+	// test for empty pod
+	expected = "external"
+	result = getNamespaceOnly(nil)
+	if result != expected {
+		t.Fatalf("Expected: %v, but got result: %v", expected, result)
+	}
+}
+
 // Test if getPacketDropMessage() works for pods
 func TestGetPacketDropMessageForPods(t *testing.T) {
 	namespace := "pod-name-test"

--- a/event/poster.go
+++ b/event/poster.go
@@ -112,7 +112,9 @@ func (poster *Poster) handle(packetDrop drop.PacketDrop) error {
 			return err
 		}
 	}
-	metrics.GetInstance().ProcessPacketDrop(srcName, dstName)
+	metrics_instance := metrics.GetInstance()
+	metrics_instance.ProcessPacketDrop(getNamespaceOnly(srcPod), "egress")
+	metrics_instance.ProcessPacketDrop(getNamespaceOnly(dstPod), "ingress")
 	// update poster's eventSubmitTimeMap
 	poster.eventSubmitTimeMap[packetDrop.SrcIP+packetDrop.DstIP] = time.Now()
 	return nil

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -31,8 +31,8 @@ func initMetricsSingleton() {
 		Help: "Counter for number of packet drops handled; excludes expired and duplicates.",
 	},
 		[]string{
-			"src",
-			"dst",
+			"namespace",
+			"direction",
 		},
 	)
 
@@ -50,9 +50,9 @@ func (m *Metrics) GetHandler() http.Handler {
 }
 
 // Update the metrics by given service name
-func (m *Metrics) ProcessPacketDrop(src, dst string) {
+func (m *Metrics) ProcessPacketDrop(namespace, direction string) {
 	m.packetDropsCount.With(prometheus.Labels{
-		"src": src,
-		"dst": dst,
+		"namespace": namespace,
+		"direction": direction,
 	}).Inc()
 }


### PR DESCRIPTION
Increment packet drop counts by direction & namespace (potential values: 'ingress' & 'egress').

If it isn't a pod, the namespace is called 'hostNetwork' if it isn't external.
If it is external -- merely called 'external' without a reverse DNS lookup.